### PR TITLE
Fetch timing data for suite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,10 @@
 steps:
+  - label: "Fetch timing data"
+    command: .buildkite/steps/fetch_timing_data
+    key: timing_data
+    agents:
+      queue: "hosted-queue"
+
   - label: ":rspec: RSpec unit"
     command: .buildkite/steps/run
     key: unit

--- a/.buildkite/steps/fetch_timing_data
+++ b/.buildkite/steps/fetch_timing_data
@@ -5,4 +5,10 @@ set -e
 docker build -t app --load .
 docker run \
   --env API_ACCESS_TOKEN \
+  -v $(pwd):/app \
   -it --rm app sh -c "bin/fetch_timing_data.rb"
+
+buildkite-agent artifact upload timings.csv
+buildkite-agent artifact upload annotation.md
+cat annotation.md | buildkite-agent annotate
+

--- a/.buildkite/steps/fetch_timing_data
+++ b/.buildkite/steps/fetch_timing_data
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+docker build -t app --load .
+docker run \
+  --env API_ACCESS_TOKEN \
+  -it --rm app sh -c "bin/fetch_timing_data.rb"

--- a/bin/fetch_timing_data.rb
+++ b/bin/fetch_timing_data.rb
@@ -2,13 +2,14 @@
 
 require 'net/http'
 require 'uri'
+require 'json'
+require 'csv'
 
 spec_files = Dir["spec/**/*.rb"]
 paths = spec_files.join("&paths[]=")
 
 # Define the URL and Bearer token
 url = "https://api.buildkite.com/v2/analytics/organizations/jimjams/suites/ta-example/test_files?paths[]=#{paths}"
-puts url
 bearer_token = ENV["API_ACCESS_TOKEN"]
 
 if bearer_token.nil?
@@ -25,4 +26,19 @@ response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https
 end
 
 # Output the response body
-puts response.body
+timings = JSON.parse(response.body)
+
+CSV.open("timings.csv", "wb") do |csv|
+  timings.to_a.each do |row|
+    csv << row
+  end
+end
+
+File.open("annotation.md", 'w') do |file|
+  file.puts("|file|time|")
+  file.puts("|-|-|")
+
+  timings.each do |key, value|
+    file.puts("|#{key}|#{value}|")
+  end
+end

--- a/bin/fetch_timing_data.rb
+++ b/bin/fetch_timing_data.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+require 'net/http'
+require 'uri'
+
+spec_files = Dir["spec/**/*.rb"]
+paths = spec_files.join("&paths[]=")
+
+# Define the URL and Bearer token
+url = "https://api.buildkite.com/v2/analytics/organizations/jimjams/suites/ta-example/test_files?paths[]=#{paths}"
+puts url
+bearer_token = ENV["API_ACCESS_TOKEN"]
+
+if bearer_token.nil?
+  puts "No API Access Token"
+  return
+end
+
+uri = URI.parse(url)
+request = Net::HTTP::Get.new(uri)
+request["Authorization"] = "Bearer #{bearer_token}"
+request["Content-Type"] = "application/json"
+response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+  http.request(request)
+end
+
+# Output the response body
+puts response.body


### PR DESCRIPTION
Annotate the build with timing data to demonstrate how it's possible to query the test_files endpoint to fetch timing data. 

![CleanShot 2024-06-05 at 13 33 40](https://github.com/jameshill/example-test-suite/assets/395/464e896b-9cd8-4d44-bae0-711cb42a2d55)
