### PR TITLE
Switch analytics ingestion to OIDC, speed up plan steps, update README

### DIFF
--- a/.buildkite/steps/feature-tests.sh
+++ b/.buildkite/steps/feature-tests.sh
@@ -2,14 +2,6 @@
 
 set -e
 
-SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
-export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
-if [[ -n "$BUILDKITE_ANALYTICS_TOKEN" ]]; then
-  echo "OIDC token fetched successfully for audience: ${SUITE_URL}"
-else
-  echo "ERROR: Failed to fetch OIDC token for audience: ${SUITE_URL}" >&2
-  exit 1
-fi
 export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=$(buildkite-agent secret get API_ACCESS_TOKEN)
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=${RETRYCOUNT:-1}
 
@@ -23,6 +15,16 @@ else
 fi
 
 docker build -f $DOCKERFILE -t app --load .
+
+# Fetch the OIDC token after the Docker build so it doesn't expire before the collector uploads
+SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
+export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
+if [[ -n "$BUILDKITE_ANALYTICS_TOKEN" ]]; then
+  echo "OIDC token fetched successfully for audience: ${SUITE_URL}"
+else
+  echo "ERROR: Failed to fetch OIDC token for audience: ${SUITE_URL}" >&2
+  exit 1
+fi
 
 echo "+++ bktec"
 docker run \

--- a/.buildkite/steps/feature-tests.sh
+++ b/.buildkite/steps/feature-tests.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent secret get FEATURE_SUITE_TOKEN)
+SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
+export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
 export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=$(buildkite-agent secret get API_ACCESS_TOKEN)
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=${RETRYCOUNT:-1}
 

--- a/.buildkite/steps/feature-tests.sh
+++ b/.buildkite/steps/feature-tests.sh
@@ -4,6 +4,12 @@ set -e
 
 SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
 export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
+if [[ -n "$BUILDKITE_ANALYTICS_TOKEN" ]]; then
+  echo "OIDC token fetched successfully for audience: ${SUITE_URL}"
+else
+  echo "ERROR: Failed to fetch OIDC token for audience: ${SUITE_URL}" >&2
+  exit 1
+fi
 export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=$(buildkite-agent secret get API_ACCESS_TOKEN)
 export BUILDKITE_TEST_ENGINE_RETRY_COUNT=${RETRYCOUNT:-1}
 

--- a/.buildkite/steps/feature-tests.sh
+++ b/.buildkite/steps/feature-tests.sh
@@ -19,12 +19,6 @@ docker build -f $DOCKERFILE -t app --load .
 # Fetch the OIDC token after the Docker build so it doesn't expire before the collector uploads
 SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
 export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
-if [[ -n "$BUILDKITE_ANALYTICS_TOKEN" ]]; then
-  echo "OIDC token fetched successfully for audience: ${SUITE_URL}"
-else
-  echo "ERROR: Failed to fetch OIDC token for audience: ${SUITE_URL}" >&2
-  exit 1
-fi
 
 echo "+++ bktec"
 docker run \

--- a/.buildkite/steps/plan.sh
+++ b/.buildkite/steps/plan.sh
@@ -4,12 +4,10 @@ set -e
 
 export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=$(buildkite-agent secret get API_ACCESS_TOKEN)
 
-DOCKERFILE=${DOCKERFILE:-Dockerfile}
-docker build -f $DOCKERFILE -t app --load .
-
-# Extract bktec from the Docker image to run natively for pipeline planning
+# Extract bktec directly from the official image — avoids building the full app just for planning
+BKTEC_IMAGE=$(grep 'COPY --from=buildkite/test-engine-client' Dockerfile | sed 's/.*--from=\([^ ]*\).*/\1/')
 BKTEC=$(mktemp)
-docker create --name bktec-extract app
+docker create --name bktec-extract "$BKTEC_IMAGE"
 docker cp bktec-extract:/usr/local/bin/bktec "$BKTEC"
 docker rm bktec-extract
 chmod +x "$BKTEC"

--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -4,6 +4,12 @@ set -e
 
 SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
 export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
+if [[ -n "$BUILDKITE_ANALYTICS_TOKEN" ]]; then
+  echo "OIDC token fetched successfully for audience: ${SUITE_URL}"
+else
+  echo "ERROR: Failed to fetch OIDC token for audience: ${SUITE_URL}" >&2
+  exit 1
+fi
 export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=$(buildkite-agent secret get API_ACCESS_TOKEN)
 
 DOCKERFILE=${DOCKERFILE:-Dockerfile}

--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -2,14 +2,6 @@
 
 set -e
 
-SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
-export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
-if [[ -n "$BUILDKITE_ANALYTICS_TOKEN" ]]; then
-  echo "OIDC token fetched successfully for audience: ${SUITE_URL}"
-else
-  echo "ERROR: Failed to fetch OIDC token for audience: ${SUITE_URL}" >&2
-  exit 1
-fi
 export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=$(buildkite-agent secret get API_ACCESS_TOKEN)
 
 DOCKERFILE=${DOCKERFILE:-Dockerfile}
@@ -22,6 +14,16 @@ else
 fi
 
 docker build -f $DOCKERFILE -t app --load .
+
+# Fetch the OIDC token after the Docker build so it doesn't expire before the collector uploads
+SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
+export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
+if [[ -n "$BUILDKITE_ANALYTICS_TOKEN" ]]; then
+  echo "OIDC token fetched successfully for audience: ${SUITE_URL}"
+else
+  echo "ERROR: Failed to fetch OIDC token for audience: ${SUITE_URL}" >&2
+  exit 1
+fi
 
 echo "+++ bktec"
 docker run \

--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent secret get SUITE_TOKEN)
+SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
+export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
 export BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN=$(buildkite-agent secret get API_ACCESS_TOKEN)
 
 DOCKERFILE=${DOCKERFILE:-Dockerfile}

--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -18,12 +18,6 @@ docker build -f $DOCKERFILE -t app --load .
 # Fetch the OIDC token after the Docker build so it doesn't expire before the collector uploads
 SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
 export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
-if [[ -n "$BUILDKITE_ANALYTICS_TOKEN" ]]; then
-  echo "OIDC token fetched successfully for audience: ${SUITE_URL}"
-else
-  echo "ERROR: Failed to fetch OIDC token for audience: ${SUITE_URL}" >&2
-  exit 1
-fi
 
 echo "+++ bktec"
 docker run \

--- a/README.md
+++ b/README.md
@@ -1,41 +1,100 @@
-# Example RSpec Test Suite
+# Example Test Suite for Buildkite Test Engine
 
-This is a sample RSpec Test Suite which uses Buildkite's Test Analytics 
-observability and automation tooling to track test performance, reliability
-and uses Buildkite's [test-splitter](https://github.com/buildkite/test-splitter)
-to split the suite of tests. 
+This is an internal Buildkite demo repository used for showcasing and testing [Buildkite Test Engine](https://buildkite.com/test-engine) features. It contains a fake RSpec test suite where each spec uses `sleep` calls to simulate realistic test durations — there is no real application under test.
 
-## Fetching the Test Splitter
+## Purpose
 
-The [Dockerfile](./Dockerfile) fetches the test-splitter binary from GitHub and
-builds it into the Docker container. This is then called by the [./.buildkite/steps/run](./.buildkite/steps/run)
-Bash script. 
+The repo is used to demonstrate:
 
-### Include/Exclude filters
+- **Intelligent test splitting** via [`bktec`](https://github.com/buildkite/test-engine-client) — splits tests across parallel nodes using historical timing data (bin-packing) rather than naive round-robin
+- **Dynamic parallelism** — plan steps calculate optimal node count then upload a generated pipeline
+- **OIDC authentication** — tests ingest results using short-lived OIDC tokens instead of long-lived static suite tokens
+- **Test ownership** — flaky tests are automatically assigned to owning teams via `TESTOWNERS`
+- **Bin-packing plan visualisation** — after planning, a chart and Claude-generated analysis annotation are added to the build
 
-This example suite uses `BUILDKITE_SPLITTER_TEST_FILE_PATTERN` env var to further partition the test suite
-into `unit` and `acceptance` specs. The `BUILDKITE_SPLITTER_IDENTIFIER` env var is used to ensure that
-a unique key is used to define the two steps. 
+## Pipelines
 
+### `pipeline.yml` — Optimised (with Test Engine)
 
-## Updating Test Ownership
+Demonstrates the full Test Engine feature set:
 
-Buildkite Test Analytics offers the concept of test ownership.
+1. **Linting / Coverage / Build** groups run in parallel (fake `echo` steps)
+2. After a `wait`, two plan steps run in parallel — one for unit tests (`rspec` suite) and one for feature specs (`feature-tests` suite). Each plan step:
+   - Extracts `bktec` from the official `buildkite/test-engine-client` image
+   - Runs `bktec plan` to generate an intelligent split from historical timing data
+   - Uploads `.buildkite/dynamic-parallel-template.yml` with the calculated parallelism
+   - Fetches the full bin-packing plan from the Test Engine API, generates a chart, and posts an AI analysis annotation
+3. After another `wait`, the dynamically generated test steps run with optimal distribution
 
-By utilising a TESTOWNERS file
+### `pipeline-not-optimised.yml` — Unoptimised (baseline comparison)
 
+The same suite without intelligent splitting — static parallelism, no dynamic planning, three separate redundant feature spec steps. Intended to show what the pipeline looks like without Test Engine optimisation so the improvement is visible by comparison.
+
+## Authentication
+
+### OIDC (analytics ingestion)
+
+`test.sh` and `feature-tests.sh` request a short-lived OIDC token from the Buildkite agent and export it as `BUILDKITE_ANALYTICS_TOKEN`:
+
+```bash
+SUITE_URL="https://buildkite.com/organizations/${BUILDKITE_ORGANIZATION_SLUG}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}"
+export BUILDKITE_ANALYTICS_TOKEN=$(buildkite-agent oidc request-token --audience "$SUITE_URL" --lifetime 300)
 ```
-*login*.rb    iam
-*logout*.rb   iam
-*password*.rb iam
-*org*.rb      iam
-*team*.rb     iam
-*user*.rb     iam
 
-*checkout*.rb billing
+This requires an **OIDC policy** to be configured in each suite's Test Engine settings:
 
-smoke/*       platform
-e2e/*         platform
+```yaml
+- iss: "https://agent.buildkite.com"
+  claims:
+    organization_slug: "your-org"
+    pipeline_slug:
+      in:
+        - "your-pipeline"
+  scopes:
+    - "read_suites"
+    - "write_uploads"
 ```
 
-We can automatically assign flaky tests to their owners
+The token lifetime should exceed the longest expected duration of the Docker build + test run for that step.
+
+### Test Engine API (planning and plan retrieval)
+
+`plan.sh` uses `BUILDKITE_TEST_ENGINE_API_ACCESS_TOKEN` (stored as a Buildkite secret named `API_ACCESS_TOKEN`) for `bktec plan` and for fetching the bin-packing plan from the REST API.
+
+## Secrets required
+
+| Secret name | Used for |
+|---|---|
+| `API_ACCESS_TOKEN` | Test Engine API — planning and fetching bin-packing plans |
+
+No static suite token secrets are needed — ingestion uses OIDC.
+
+## Fake test durations
+
+`spec/spec_helper.rb` defines `spoof_duration` which each spec calls to simulate realistic timing:
+
+| Type | Duration |
+|---|---|
+| Unit | 0.1–0.3s |
+| Feature | 1–3s |
+| Slow feature | 5–10s |
+| Really slow feature | 10–30s |
+| E2E | 45–55s |
+
+An `SPOOF_ARM_MODE=true` env var applies a 0.85× duration multiplier and reduces flakiness, simulating a faster ARM architecture for demo comparisons.
+
+## Test Ownership
+
+The `TESTOWNERS` file maps glob patterns to team slugs. Flaky tests detected by Test Engine are automatically assigned to their owner:
+
+| Team | Files |
+|---|---|
+| `iam` | login, logout, password, team, user, org, workspace, flaky specs |
+| `growth` | cart, checkout, order, product, user signup specs |
+| `platform` | admin dashboard, e2e, smoke specs |
+
+## Docker
+
+`Dockerfile` builds a Ruby 3.3 Alpine image that bundles `bktec` (from `buildkite/test-engine-client:v2.2.0`) and the `buildkite-test-collector` gem. `Dockerfile.v1.1` is an alternative version for testing upgrades; set `DOCKERFILE=Dockerfile.v1.1` on a step to use it.
+
+The plan steps do **not** build the full app image — they pull just the `buildkite/test-engine-client` image to extract `bktec`, which is significantly faster.


### PR DESCRIPTION
## Summary

- **OIDC ingestion**: replaces the static `SUITE_TOKEN` / `FEATURE_SUITE_TOKEN` secrets in `test.sh` and `feature-tests.sh` with short-lived OIDC tokens requested via `buildkite-agent oidc request-token`. The audience is the full suite URL constructed from `BUILDKITE_ORGANIZATION_SLUG` and `BUILDKITE_TEST_ENGINE_SUITE_SLUG`, matching the pattern in the upcoming [docs PR #1476](https://github.com/buildkite/docs-private/pull/1476). Each suite will need an OIDC policy configured with `read_suites` + `write_uploads` scopes.
- **Plan step speedup**: `plan.sh` previously built the full app Docker image (Ruby + bundler + gems) just to extract the `bktec` binary — the main reason the optimised pipeline was slower than the unoptimised one. It now pulls `buildkite/test-engine-client` directly (version read from the Dockerfile), which is a tiny image and much faster on a cold agent.
- **README rewrite**: adds full context for agents and humans — purpose, pipeline comparison, OIDC policy snippet, secrets table, fake test duration table, ownership teams, and Docker notes.

## Test plan

- [ ] Trigger a build on this branch and confirm `bktec plan` steps complete without a full Docker build
- [ ] Confirm test steps successfully request an OIDC token and ingest results (requires OIDC policy to be set on both suites)
- [ ] Confirm the optimised pipeline wall-clock time is shorter than the unoptimised pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)