### PR TITLE
Update bktec to v2.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
     curl
 
 # test-engine-client
-COPY --from=buildkite/test-engine-client:v2.2.0 /usr/local/bin/bktec /usr/local/bin/bktec
+COPY --from=buildkite/test-engine-client:v2.4.0 /usr/local/bin/bktec /usr/local/bin/bktec
 
 # Set working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -95,6 +95,6 @@ The `TESTOWNERS` file maps glob patterns to team slugs. Flaky tests detected by 
 
 ## Docker
 
-`Dockerfile` builds a Ruby 3.3 Alpine image that bundles `bktec` (from `buildkite/test-engine-client:v2.2.0`) and the `buildkite-test-collector` gem. `Dockerfile.v1.1` is an alternative version for testing upgrades; set `DOCKERFILE=Dockerfile.v1.1` on a step to use it.
+`Dockerfile` builds a Ruby 3.3 Alpine image that bundles `bktec` (from `buildkite/test-engine-client:v2.4.0`) and the `buildkite-test-collector` gem. `Dockerfile.v1.1` is an alternative version for testing upgrades; set `DOCKERFILE=Dockerfile.v1.1` on a step to use it.
 
 The plan steps do **not** build the full app image — they pull just the `buildkite/test-engine-client` image to extract `bktec`, which is significantly faster.


### PR DESCRIPTION
Bumps `buildkite/test-engine-client` from `v2.2.0` to `v2.4.0` in `Dockerfile` and updates the version reference in `README.md`.

`Dockerfile.v1.1` is intentionally left at `v1.1.0` — it exists to demo the older version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)